### PR TITLE
Implemented ThreadPool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(libraries)
 # add_library(Interpreter_lib src/Interpreter.cpp)
 add_library(BinaryFileSystemHandler_lib src/BinaryFileSystemHandler.cpp)
 add_library(CommandLineArgumentParser_lib src/CommandLineArgumentParser.cpp)
+add_library(ThreadPool_lib src/ThreadPool.cpp)
 
 add_executable(interpreter src/main.cpp)
 target_link_libraries(
@@ -65,6 +66,12 @@ target_link_libraries(
   gtest_main
 )
 
+add_executable(ThreadPool_test tests/ThreadPoolTest.cpp)
+target_link_libraries(
+  ThreadPool_test
+  ThreadPool_lib
+  gtest_main
+)
+
 gtest_discover_tests(CommandLineArgumentParser_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-
+gtest_discover_tests(ThreadPool_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <mutex>
 #include <functional>
+#include <condition_variable>
 
 class ThreadPool {
 public:

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -11,9 +11,9 @@
 
 class ThreadPool {
 public:
-    void start();
-    void queueJob(std::function<void()>);
-    void stop();
+    bool start(int nThreads);
+    bool queueJob(std::function<void()>);
+    bool stop();
     bool isBusy();
     ~ThreadPool();
 private:

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -12,9 +12,10 @@
 class ThreadPool {
 public:
     void start();
-    void queueJob();
+    void queueJob(std::function<void()>);
     void stop();
     bool isBusy();
+    ~ThreadPool();
 private:
     void threadLoop();
 
@@ -22,7 +23,7 @@ private:
     std::mutex m_queueMutex;
     std::condition_variable m_mutexCondition;
     std::vector<std::thread> m_threads;
-    std::queue<std::function<void()>> jobs;
+    std::queue<std::function<void()>> m_jobs;
 };
 
 #endif

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -1,0 +1,28 @@
+#ifndef THREADPOOL_H
+#define THREADPOOL_H
+
+#include "Utility.h"
+
+#include <thread>
+#include <queue>
+#include <vector>
+#include <mutex>
+#include <functional>
+
+class ThreadPool {
+public:
+    void start();
+    void queueJob();
+    void stop();
+    bool isBusy();
+private:
+    void threadLoop();
+
+    bool m_shouldTerminate;
+    std::mutex m_queueMutex;
+    std::condition_variable m_mutexCondition;
+    std::vector<std::thread> m_threads;
+    std::queue<std::function<void()>> jobs;
+};
+
+#endif

--- a/include/Utility.h
+++ b/include/Utility.h
@@ -5,6 +5,7 @@
 #include <bitset>
 #include <memory>
 #include <utility>
+#include <mutex>
 
 // Represents the Result of a function that may or may not be valid
 template <typename T>
@@ -22,5 +23,7 @@ using u_ptr = std::unique_ptr<T>;
 
 template <typename T>
 using s_ptr = std::shared_ptr<T>;
+
+using u_lock = std::unique_lock<std::mutex>;
 
 #endif

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -1,4 +1,5 @@
 #include "ThreadPool.h"
+#include "Utility.h"
 
 #include <thread>
 #include <queue>
@@ -6,4 +7,68 @@
 #include <mutex>
 #include <functional>
 
+void ThreadPool::start() {
+    int nThreads = std::thread::hardware_concurrency();
+    for (int i = 0; i < nThreads; i++) {
+        m_threads.emplace_back(&ThreadPool::threadLoop, this);
+    }
 
+}
+
+void ThreadPool::queueJob(std::function<void()> job) {
+    {
+        u_lock lock(m_queueMutex);
+        m_jobs.push(job);
+    }
+
+    m_mutexCondition.notify_one();
+}
+
+void ThreadPool::stop() {
+    {
+        u_lock lock(m_queueMutex);
+        m_shouldTerminate = true;
+    }
+
+    m_mutexCondition.notify_all();
+    for (std::thread& thread : m_threads) {
+        thread.join();
+    }
+
+    m_threads.clear();
+}
+
+bool ThreadPool::isBusy() {
+    bool isBusy;
+    {
+        u_lock lock(m_queueMutex);
+        isBusy = !m_jobs.empty();
+    }
+
+    return isBusy;
+}
+
+void ThreadPool::threadLoop() {
+    while (true) {
+        std::function<void()> job;
+        {
+            u_lock lock(m_queueMutex);
+            m_mutexCondition.wait(lock, [this] {
+                return !m_jobs.empty() || m_shouldTerminate;
+            });
+
+            if (m_shouldTerminate) {
+                return;
+            }
+
+            job = m_jobs.front();
+            m_jobs.pop();
+        }
+
+        job();
+    }
+}
+
+ThreadPool::~ThreadPool() {
+    stop();
+}

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -1,0 +1,9 @@
+#include "ThreadPool.h"
+
+#include <thread>
+#include <queue>
+#include <vector>
+#include <mutex>
+#include <functional>
+
+

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -7,24 +7,26 @@
 #include <mutex>
 #include <functional>
 
-void ThreadPool::start() {
-    int nThreads = std::thread::hardware_concurrency();
+bool ThreadPool::start(int nThreads) {
     for (int i = 0; i < nThreads; i++) {
         m_threads.emplace_back(&ThreadPool::threadLoop, this);
     }
 
+    return true;
 }
 
-void ThreadPool::queueJob(std::function<void()> job) {
+bool ThreadPool::queueJob(std::function<void()> job) {
     {
         u_lock lock(m_queueMutex);
         m_jobs.push(job);
     }
 
     m_mutexCondition.notify_one();
+
+    return true;
 }
 
-void ThreadPool::stop() {
+bool ThreadPool::stop() {
     {
         u_lock lock(m_queueMutex);
         m_shouldTerminate = true;
@@ -36,6 +38,8 @@ void ThreadPool::stop() {
     }
 
     m_threads.clear();
+
+    return true;
 }
 
 bool ThreadPool::isBusy() {

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -2,8 +2,6 @@
 #include "Utility.h"
 
 #include <thread>
-#include <queue>
-#include <vector>
 #include <mutex>
 #include <functional>
 

--- a/tests/ThreadPoolTest.cpp
+++ b/tests/ThreadPoolTest.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "ThreadPool.h"
+
+#include <chrono>
+#include <thread>
+#include <functional>
+
+class ThreadPoolTest : public ::testing::Test {
+protected:
+    ThreadPool m_tp;
+    int nThreads = 4;
+};
+
+TEST_F(ThreadPoolTest, StartTest) {
+    EXPECT_TRUE(m_tp.start(nThreads));
+}
+
+TEST_F(ThreadPoolTest, StopTest) {
+    EXPECT_TRUE(m_tp.stop());
+}
+
+TEST_F(ThreadPoolTest, QueueJobTest) {
+    m_tp.start(nThreads);
+
+    EXPECT_TRUE(m_tp.queueJob([] () {}));
+}
+
+TEST_F(ThreadPoolTest, IsBusyTest) {
+    m_tp.start(1);
+
+    // Define lambda to simulate work
+    std::function<void()> job = [] () {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    };
+
+    EXPECT_FALSE(m_tp.isBusy());
+
+    m_tp.queueJob(job);
+    m_tp.queueJob(job);
+
+    EXPECT_TRUE(m_tp.isBusy());
+}


### PR DESCRIPTION
Implemented a ThreadPool. Creates threads held in a vector that constantly try to receive jobs from a queue to work on. Jobs can be added to a queue, and can be stopped when no longer needed. Will automatically stop when destroyed.

Also added unit tests for the ThreadPool class.