### PR TITLE
Defined a Interpreter class

### DIFF
--- a/include/Interpreter.h
+++ b/include/Interpreter.h
@@ -1,4 +1,24 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 
+#include "Utility.h"
+#include "RegisterTable.h"
+#include "ThreadPool.h"
+#include "InstructionDecoder.h"
+
+#include <vector>
+
+class Interpreter {
+public:
+    u_ptr<RegisterTable> interpret(const Program& program) const;
+private:
+    void processInstructions(ThreadPool& tp, const InstructionDecoder& id, const Program& program) const;
+    void instructionThreadWork(const InstructionDecoder& id, 
+        const Iterator<Program>& start, const Iterator<Program>& end, 
+        Iterator<std::vector<DecodedInstruction>>& diStart) const;
+    void immediateThreadWork(const InstructionDecoder& id, 
+        const Iterator<Program>& start, const Iterator<Program>& end, 
+        Iterator<std::vector<DecodedImmediate>>& diStart) const;
+};
+
 #endif

--- a/include/Interpreter.h
+++ b/include/Interpreter.h
@@ -12,7 +12,8 @@ class Interpreter {
 public:
     u_ptr<RegisterTable> interpret(const Program& program) const;
 private:
-    void processInstructions(ThreadPool& tp, const InstructionDecoder& id, const Program& program) const;
+    void processInstructions(ThreadPool& tp, const InstructionDecoder& id, const Program& program,
+        std::vector<DecodedInstruction>& decodedInstructions, std::vector<DecodedImmediate>& decodedImmediates) const;
     void instructionThreadWork(const InstructionDecoder& id, 
         const Iterator<Program>& start, const Iterator<Program>& end, 
         Iterator<std::vector<DecodedInstruction>>& diStart) const;

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -16,10 +16,10 @@ public:
     bool start(int nThreads);
     bool stop();
     bool isBusy();
-    bool addAndWait(std::function<void()> addJobs);
+    bool queueJob(std::function<void()> job);
+    bool wait();
     ~ThreadPool();
 private:
-    bool queueJob(std::function<void()> job);
     void threadLoop();
 
     bool m_shouldTerminate;

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -9,15 +9,17 @@
 #include <mutex>
 #include <functional>
 #include <condition_variable>
+#include <atomic>
 
 class ThreadPool {
 public:
     bool start(int nThreads);
-    bool queueJob(std::function<void()>);
     bool stop();
     bool isBusy();
+    bool addAndWait(std::function<void()> addJobs);
     ~ThreadPool();
 private:
+    bool queueJob(std::function<void()> job);
     void threadLoop();
 
     bool m_shouldTerminate;
@@ -25,6 +27,10 @@ private:
     std::condition_variable m_mutexCondition;
     std::vector<std::thread> m_threads;
     std::queue<std::function<void()>> m_jobs;
+
+    std::mutex m_mainThreadMutex;
+    std::condition_variable m_mainThreadCondition;
+    std::atomic<int> m_nProcessesRunning;
 };
 
 #endif

--- a/include/Utility.h
+++ b/include/Utility.h
@@ -11,6 +11,9 @@
 template <typename T>
 using Result = std::pair<bool, T>;
 
+template <typename C>
+using Iterator = T::iterator;
+
 // An Instruction is 32 bits wide.
 using Instruction = std::bitset<32>;
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -1,0 +1,67 @@
+#include "Interpreter.h"
+#include "Utility.h"
+#include "RegisterTable.h"
+#include "ThreadPool.h"
+#include "InstructionDecoder.h"
+
+#include <memory>
+#include <thread>
+#include <vector>
+
+u_ptr<RegisterTable> Interpreter::interpret(const Program& program) const {
+    u_ptr<RegisterArray> registerTableArray(new RegisterArray());
+    u_ptr<RegisterTable> rt(new RegisterTable(std::move(registerTableArray)));
+
+    ThreadPool tp;
+    tp.start(std::thread::hardware_concurrency());
+
+    InstructionDecoder id;
+
+    processInstructions(tp, id, program);
+
+    return std::move(rt);
+}
+
+void Interpreter::processInstructions(ThreadPool& tp, const InstructionDecoder& id, const Program& program) const {
+    int programSize = program.size();
+    int maxConcurrency = std::thread::hardware_concurrency();
+    int nJobs = programSize > maxConcurrency ? maxConcurrency : programSize;
+
+    int jobSize = programSize / nJobs;
+    int extraJobs = programSize % nJobs;
+
+    InstructionDecoder id;
+
+    auto programEnd = program.end();
+    for (auto it = program.begin(); it != programEnd;) {
+        int currentJobSize = jobSize;
+        if (extraJobs > 0) {
+            currentJobSize++;
+            extraJobs--;
+        } 
+    }
+};
+
+#include <algorithm>
+
+void Interpreter::instructionThreadWork(const InstructionDecoder& id, 
+    const Iterator<Program>& start, const Iterator<Program>& end, 
+    Iterator<std::vector<DecodedInstruction>>& diStart) const {
+
+    auto diIterator = diStart;
+
+    std::for_each(start, end, [&] (const Instruction& i) -> void {
+        *(diIterator++) = id.decodeInstruction(i);
+    });
+}
+
+void Interpreter::immediateThreadWork(const InstructionDecoder& id, 
+    const Iterator<Program>& start, const Iterator<Program>& end, 
+    Iterator<std::vector<DecodedImmediate>>& diStart) const {
+
+    auto diIterator = diStart;
+
+    std::for_each(start, end, [&] (const Instruction& i) -> void {
+        *(diIterator++) = id.generateImmediate(i);
+    });
+}


### PR DESCRIPTION
Defined an Interpreter class. The only public function is Interpreter::interpret. Currently, all interpret does is split up all machine code from a Program into smaller decode jobs of roughly equal size and add them all to the ThreadPool job queue.

Also updated ThreadPool to allow safely waiting for all jobs added to the queue to finish. 